### PR TITLE
Fixed non-functional documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You may also need to install udev rules. PlatformIO have a good [instructions](h
 
 Ubuntu users also must enable "Access USB hardware directly" on the Ubuntu Store Software store:
 
-![Ubuntu premissions](data/screenshots/ubuntu_access_usb_directly.png)
+![Ubuntu permissions](data/screenshots/ubuntu_access_usb_directly.png)
 
 or from command line:
 

--- a/src/window.py
+++ b/src/window.py
@@ -169,7 +169,7 @@ class TaunoMonitorWindow(Adw.ApplicationWindow):
 
     def update_time_tag(self):
         """ Creates new tag with a new color """
-        # TODO How to change allready existing tag color?
+        # TODO How to change already existing tag color?
         #print("update_time_tag")
         self.text_buffer = self.input_text_view.get_buffer()
         color = self.settings.get_string("saved-time-color")

--- a/src/window.py
+++ b/src/window.py
@@ -257,7 +257,7 @@ class TaunoMonitorWindow(Adw.ApplicationWindow):
                 # Create log file
                 self.log_file_exist = self.logging.create_file(log_file_path)
         else:
-            print("log switch deactive")
+            print("log switch deactivate")
             self.logging.close_file()
             self.write_logs = False
 


### PR DESCRIPTION
Corrected typographical inconsistencies and minor grammar issues.

### Breakdown:
- `README.md`, line 49: `premissions` → `permissions`
- `src/window.py`, line 172: `allready` → `already`
- `src/window.py`, line 260: `deactive` → `deactivate`

All modifications are textual and safe.