### PR TITLE
ExternalProgram.path is deprecated since 0.55.0

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ gnome.compile_resources('tauno-monitor',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', get_option('prefix') / get_option('localedir'))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
As `external_program.path()` is deprecated it should be replaced with `external_program.full_path()` which is done by this PR.

[https://mesonbuild.com/Reference-manual_returned_external_program.html#external_programpath](https://mesonbuild.com/Reference-manual_returned_external_program.html#external_programpath)

Closes #23 